### PR TITLE
Removed the app.tabChange event listener

### DIFF
--- a/src/TruePeople.SharePreview.v7/App_Plugins/TruePeopleSharePreview/components/singlesharelink.directive.js
+++ b/src/TruePeople.SharePreview.v7/App_Plugins/TruePeopleSharePreview/components/singlesharelink.directive.js
@@ -9,14 +9,6 @@
             $scope.copyShareLink = function (link) {
                 sharePreviewCopyService.copyShareLink(link);
             };
-
-            eventsService.on("app.tabChange", function (name, args) {
-                if (args.alias == "umbContent" || args.alias == "umbInfo") {
-                    $scope.shouldShow = true;
-                } else {
-                    $scope.shouldShow = false;
-                }
-            });
         }
 
         var directive = {


### PR DESCRIPTION
Removed the app.tabChange event listener because the share button should always be shown regardless of the active tab in Umbraco 7.