### PR TITLE
Bugfix for previewing never published content

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,10 @@ This will generate the packages inside the same folder.
 
 # Changelog
 
+## v1.0.3
+
+- Fixed stack overflow exception bug when trying to preview content that has never been published before
+
 ## v1.0.2
 
 - Fixed null exception bug when checking if a shareable link exists for content without a template

--- a/src/TruePeople.SharePreview.v7/EventHandlers/Handlers/TPPreviewShareRouteHandler.cs
+++ b/src/TruePeople.SharePreview.v7/EventHandlers/Handlers/TPPreviewShareRouteHandler.cs
@@ -49,6 +49,7 @@ namespace TruePeople.SharePreview.EventHandlers.Handlers
 
                 if (latestNodeVersion != null && latestNodeVersion.Version == sharePreviewContext.NewestVersionId && wasEdited)
                 {
+                    EnableForcedPreview(umbracoContext);
                     var page = umbracoContext.ContentCache.GetById(true, sharePreviewContext.NodeId);
 
                     //Since we don't use the base.PreparePublishedRequest, the culture isn't being set correctly.
@@ -110,6 +111,16 @@ namespace TruePeople.SharePreview.EventHandlers.Handlers
                 //Redirect to configured page.
                 HttpContext.Current.Response.Redirect(url);
             }
+        }
+
+        /// <summary>
+        /// Sets the current Umbraco context preview mode to true to ensure content
+        /// that has never been published before can be properly retrieved.
+        /// </summary>
+        /// <param name="umbracoContext"></param>
+        private void EnableForcedPreview(UmbracoContext umbracoContext)
+        {
+            umbracoContext.InPreviewMode = true;
         }
     }
 }


### PR DESCRIPTION
Added EnableForcedPreview() back to the route handler to ensure previews work for content that has been saved but never yet published.